### PR TITLE
Fix the incorrect behavior of the table's row styles

### DIFF
--- a/formats/table/attributors/cell_config.js
+++ b/formats/table/attributors/cell_config.js
@@ -1,6 +1,6 @@
 export const cellConfig = {
   name: 'cell',
-  allowedTags: ['TH', 'TD'],
+  allowedTags: ['TH', 'TD', 'TR'],
 };
 
 export const TABLE_CELL_ATTRIBUTES = [

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -415,7 +415,7 @@ function matchAlias(format, node, delta) {
 }
 
 function matchAttributor(node, delta, scroll) {
-  if (['TD', 'TH', 'TABLE'].indexOf(node.tagName) === -1) {
+  if (['TD', 'TH', 'TR', 'TABLE'].indexOf(node.tagName) === -1) {
     const attributes = Attributor.keys(node);
     const classes = ClassAttributor.keys(node);
     const styles = StyleAttributor.keys(node);

--- a/modules/table/index.js
+++ b/modules/table/index.js
@@ -17,9 +17,18 @@ import {
 import isDefined from '../../utils/is_defined';
 import { deltaEndsWith, applyFormat } from '../clipboard';
 import makeTableArrowHandler from './utils/make_table_arrow_handler';
-import prepareAttributeMatcher from './utils/prepare_attr_matcher';
-import { TABLE_FORMATS } from '../../formats/table/attributors/table';
-import { CELL_FORMATS } from '../../formats/table/attributors/cell';
+import {
+  prepareAttributeMatcher,
+  prepareCellAttributeMatcher,
+} from './utils/prepare_attr_matcher';
+import {
+  TABLE_ATTRIBUTORS,
+  TABLE_FORMATS,
+} from '../../formats/table/attributors/table';
+import {
+  CELL_ATTRIBUTORS,
+  CELL_FORMATS,
+} from '../../formats/table/attributors/cell';
 
 const EMPTY_RESULT = [null, null, null, -1];
 
@@ -62,8 +71,14 @@ class Table extends Module {
     });
 
     this.quill.clipboard.addMatcher('td, th', matchCell);
-    this.quill.clipboard.addMatcher('table', prepareAttributeMatcher('table'));
-    this.quill.clipboard.addMatcher('td, th', prepareAttributeMatcher('cell'));
+    this.quill.clipboard.addMatcher(
+      'table',
+      prepareAttributeMatcher(TABLE_ATTRIBUTORS),
+    );
+    this.quill.clipboard.addMatcher(
+      'td, th',
+      prepareCellAttributeMatcher(CELL_ATTRIBUTORS),
+    );
   }
 
   addKeyboardHandlers() {

--- a/modules/table/lite.js
+++ b/modules/table/lite.js
@@ -17,9 +17,18 @@ import makeTableArrowHandler from './utils/make_table_arrow_handler';
 import insertParagraphAbove from './utils/insert_pr_below';
 import insertParagraphBelow from './utils/insert_pr_above';
 import tableSide from './utils/table_side';
-import prepareAttributeMatcher from './utils/prepare_attr_matcher';
-import { TABLE_FORMATS } from '../../formats/table/attributors/table';
-import { CELL_FORMATS } from '../../formats/table/attributors/cell';
+import {
+  prepareAttributeMatcher,
+  prepareCellAttributeMatcher,
+} from './utils/prepare_attr_matcher';
+import {
+  TABLE_ATTRIBUTORS,
+  TABLE_FORMATS,
+} from '../../formats/table/attributors/table';
+import {
+  CELL_ATTRIBUTORS,
+  CELL_FORMATS,
+} from '../../formats/table/attributors/cell';
 
 const EMPTY_RESULT = [null, null, null, -1];
 
@@ -58,8 +67,14 @@ class TableLite extends Module {
     this.tableBlots.forEach((blotName) => this.quill.clipboard.addTableBlot(blotName));
 
     this.quill.clipboard.addMatcher('tr', matchTable);
-    this.quill.clipboard.addMatcher('table', prepareAttributeMatcher('table'));
-    this.quill.clipboard.addMatcher('td, th', prepareAttributeMatcher('cell'));
+    this.quill.clipboard.addMatcher(
+      'table',
+      prepareAttributeMatcher(TABLE_ATTRIBUTORS),
+    );
+    this.quill.clipboard.addMatcher(
+      'td, th',
+      prepareCellAttributeMatcher(CELL_ATTRIBUTORS),
+    );
   }
 
   addKeyboardHandlers() {

--- a/modules/table/utils/prepare_attr_matcher.js
+++ b/modules/table/utils/prepare_attr_matcher.js
@@ -1,33 +1,75 @@
 import { Scope } from 'parchment';
 import OverriddenAttributor from '../../../attributors/attributor';
 import OverriddenStyleAttributor from '../../../attributors/style_attributor';
-import { CELL_ATTRIBUTORS } from '../../../formats/table/attributors/cell';
-import { TABLE_ATTRIBUTORS } from '../../../formats/table/attributors/table';
 import { applyFormat } from '../../clipboard';
 
-const ATTRIBUTORS = {
-  table: TABLE_ATTRIBUTORS,
-  cell: CELL_ATTRIBUTORS,
-};
+function writeToRecord(record, key, value, override) {
+  record[key] = !override && record[key] ? record[key] : value;
+}
 
-export default function prepareAttributeMatcher(type) {
-  const attributors = ATTRIBUTORS[type];
+function fillFormats(attributes, node, scroll, attributors, result, override) {
+  attributes
+    .filter((name) => !!name)
+    .forEach((name) => {
+      const queryAttr = scroll.query(name, Scope.ATTRIBUTE);
+      if (queryAttr !== null) {
+        const queryAttrValue = queryAttr.value(node);
+        if (queryAttrValue) {
+          writeToRecord(result, queryAttr.attrName, queryAttrValue, override);
+          return;
+        }
+      }
+
+      const attr = attributors[name];
+      if (attr != null && (attr.attrName === name || attr.keyName === name)) {
+        const attrValue = attr.value(node) || undefined;
+        writeToRecord(result, attr.attrName, attrValue, override);
+      }
+    });
+
+  return result;
+}
+
+export function prepareAttributeMatcher(attributors) {
   return (node, delta, scroll) => {
     const attributes = OverriddenAttributor.keys(node);
     const styles = OverriddenStyleAttributor.keys(node);
-    const formats = {};
-    attributes.concat(styles).forEach((name) => {
-      let attr = scroll.query(name, Scope.ATTRIBUTE);
-      if (attr != null) {
-        formats[attr.attrName] = attr.value(node);
-        if (formats[attr.attrName]) return;
-      }
-      attr = attributors[name];
-      if (attr != null && (attr.attrName === name || attr.keyName === name)) {
-        attr = attributors[name];
-        formats[attr.attrName] = attr.value(node) || undefined;
-      }
-    });
+
+    const formats = {
+      ...fillFormats(attributes, node, scroll, attributors, {}, true),
+      ...fillFormats(styles, node, scroll, attributors, {}, true),
+    };
+
+    if (Object.keys(formats).length > 0) {
+      return applyFormat(delta, formats);
+    }
+    return delta;
+  };
+}
+
+export function prepareCellAttributeMatcher(attributors) {
+  return (node, delta, scroll) => {
+    const attributes = OverriddenAttributor.keys(node);
+    const styles = OverriddenStyleAttributor.keys(node);
+    const parentTrNode = node.parentNode?.tagName === 'TR' ? node.parentNode : undefined;
+
+    let formats = {
+      ...fillFormats(attributes, node, scroll, attributors, {}, true),
+      ...fillFormats(styles, node, scroll, attributors, {}, true),
+    };
+
+    if (parentTrNode) {
+      const parentStyles = OverriddenStyleAttributor.keys(parentTrNode);
+      formats = fillFormats(
+        parentStyles,
+        parentTrNode,
+        scroll,
+        attributors,
+        formats,
+        false,
+      );
+    }
+
     if (Object.keys(formats).length > 0) {
       return applyFormat(delta, formats);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "devextreme-quill",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "devextreme-quill",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "core-js": "^3.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devextreme-quill",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Core of the DevExtreme HtmlEditor",
   "author": "Developer Express Inc.",
   "main": "dist/dx-quill.js",

--- a/test/unit/modules/table_lite.js
+++ b/test/unit/modules/table_lite.js
@@ -20,9 +20,9 @@ describe('Table Module', function () {
         },
       });
       const markup = `
-      <table style="border: 2px dashed green; background-color: azure;" width="800px" height="600px">
+      <table style='border: 2px dashed green; background-color: azure;' width='800px' height='600px'>
         <tbody>
-          <tr><td style="border: 2px solid red; text-align: center; vertical-align: bottom; background-color: aliceblue; padding-top: 10px;">a1</td><td width="100px" height="100px" style="padding: 20px;">a2</td><td>a3</td></tr>
+          <tr><td style='border: 2px solid red; text-align: center; vertical-align: bottom; background-color: aliceblue; padding-top: 10px;'>a1</td><td width='100px' height='100px' style='padding: 20px;'>a2</td><td>a3</td></tr>
         </tbody>
       </table>
       `;
@@ -78,11 +78,11 @@ describe('Table Module', function () {
 
     it('initial markup with formatting', function () {
       const markup = `
-      <table style="background-color: azure;">
+      <table style='background-color: azure;'>
         <tbody>
           <tr>
-            <td style="background-color: aliceblue;">a1</td>
-            <td style="padding: 20px;">a2</td>
+            <td style='background-color: aliceblue;'>a1</td>
+            <td style='padding: 20px;'>a2</td>
             <td>a3</td></tr>
         </tbody>
       </table>
@@ -102,14 +102,14 @@ describe('Table Module', function () {
         <table>
           <thead>
             <tr>
-              <th data-tablelite-header-row="1">H1</th>
-              <th data-tablelite-header-row="1">H2</th>
+              <th data-tablelite-header-row='1'>H1</th>
+              <th data-tablelite-header-row='1'>H2</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td data-tablelite-row="a">A1</td>
-              <td data-tablelite-row="a">A2</td>
+              <td data-tablelite-row='a'>A1</td>
+              <td data-tablelite-row='a'>A2</td>
             </tr>
           </tbody>
         </table>`,
@@ -125,14 +125,14 @@ describe('Table Module', function () {
       <table>
         <thead>
           <tr>
-            <th data-tablelite-header-row="1">H1</th>
-            <th data-tablelite-header-row="1">H2</th>
+            <th data-tablelite-header-row='1'>H1</th>
+            <th data-tablelite-header-row='1'>H2</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td data-tablelite-row="a">A1</td>
-            <td data-tablelite-row="a">A2</td>
+            <td data-tablelite-row='a'>A1</td>
+            <td data-tablelite-row='a'>A2</td>
           </tr>
         </tbody>
       </table>`);
@@ -140,7 +140,7 @@ describe('Table Module', function () {
 
     it('initial markup with thead and formatting', function () {
       const markup = `
-      <table style="background-color: azure;">
+      <table style='background-color: azure;'>
         <thead>
           <tr>
             <th>h1</th>
@@ -150,8 +150,8 @@ describe('Table Module', function () {
         </thead>
         <tbody>
           <tr>
-            <td style="background-color: aliceblue;">a1</td>
-            <td style="padding: 20px;">a2</td>
+            <td style='background-color: aliceblue;'>a1</td>
+            <td style='padding: 20px;'>a2</td>
             <td>a3</td>
           </tr>
         </tbody>
@@ -223,8 +223,8 @@ describe('Table Module', function () {
         Quill,
         `<table>
           <tr>
-            <td data-row="1">1</td>
-            <td data-row="2">2</td>
+            <td data-row='1'>1</td>
+            <td data-row='2'>2</td>
           </tr>
         </table>`,
         this.container,
@@ -248,6 +248,243 @@ describe('Table Module', function () {
       `,
         true,
       );
+    });
+
+    it('initial markup with cell color', function () {
+      const markup = `
+      <table>
+        <thead>
+          <tr>
+            <th style='color: red'>
+              <p>h1</p>
+            </th>
+            <th style='color: red'>
+              <p>h2</p>
+            </th>
+            <th style='color: blue'>
+              <p>h3</p>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style='color: red'>
+              <p>a1</p>
+            </td>
+            <td style='color: red'>
+              <p>a2</p>
+            </td>
+            <td style='color: blue'>
+              <p>a3</p>
+            </td>
+          </tr>
+          <tr>
+            <td style='color: green'>
+              <p>b1</p>
+            </td>
+            <td style='color: yellow'>
+              <p>b2</p>
+            </td>
+            <td style='color: purple'>
+              <p>b3</p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      `;
+
+      const expectedHtml = `
+      <table>
+        <thead>
+          <tr data-table-row='1'>
+            <th>
+              <span style='color: red;'>h1</span>
+            </th>
+            <th>
+              <span style='color: red;'>h2</span>
+            </th>
+            <th>
+              <span style='color: blue;'>h3</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <span style='color: red;'>a1</span>
+            </td>
+            <td>
+              <span style='color: red;'>a2</span>
+            </td>
+            <td>
+              <span style='color: blue;'>a3</span>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <span style='color: green;'>b1</span>
+            </td>
+            <td>
+              <span style='color: yellow;'>b2</span>
+            </td>
+            <td>
+              <span style='color: purple;'>b3</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>`;
+
+      const quill = this.initialize(Quill, markup, this.container, {
+        modules: {
+          table: true,
+        },
+      });
+      expect(quill.root).toEqualHTML(expectedHtml, true);
+    });
+
+    it('initial markup with row styles', function () {
+      const quill = this.initialize(
+        Quill,
+        `<table>
+          <tr style='text-align: right; background-color: #ff0000'>
+            <td>1</td>
+            <td>2</td>
+          </tr>
+        </table>`,
+        this.container,
+        { modules: { table: true } },
+      );
+
+      expect(quill.root.innerHTML).toEqualHTML(`
+      <table>
+        <tbody>
+        <tr>
+          <td style='background-color: rgb(255, 0, 0); text-align: right;'>
+            1
+          </td>
+          <td style='background-color: rgb(255, 0, 0); text-align: right;'>
+            2
+          </td>
+        </tr>
+        </tbody>
+      </table>
+      `);
+    });
+
+    it('initial markup with row and cell styles that intersect', function () {
+      const quill = this.initialize(
+        Quill,
+        `<table>
+          <tr style='text-align: right; background-color: #ff0000;'>
+            <td>1</td>
+            <td style='text-align: center; background-color: #00ff00'>2</td>
+          </tr>
+        </table>`,
+        this.container,
+        { modules: { table: true } },
+      );
+
+      expect(quill.root).toEqualHTML(`
+      <table>
+        <tbody>
+        <tr data-table-row='1'>
+          <td style='background-color: rgb(255, 0, 0); text-align: right;'>
+            1
+          </td>
+          <td style='background-color: rgb(0, 255, 0); text-align: center; '>
+            2
+          </td>
+        </tr>
+        </tbody>
+      </table>
+      `);
+    });
+
+    it('initial markup with row and cell styles that dont intersect', function () {
+      const quill = this.initialize(
+        Quill,
+        `<table>
+          <tr style='text-align: right; background-color: #3e3e3e;'>
+            <td>1</td>
+            <td style='color: #fff'>2</td>
+          </tr>
+          </table>`,
+        this.container,
+        { modules: { table: true } },
+      );
+
+      expect(quill.root).toEqualHTML(`
+      <table>
+        <tbody>
+        <tr data-table-row='1'>
+          <td style='background-color: rgb(62, 62, 62); text-align: right;'>
+            1
+          </td>
+          <td style='background-color: rgb(62, 62, 62); text-align: right;'>
+            <span style='color: rgb(255, 255, 255);'>2</span>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+      `);
+    });
+
+    it('initial markup with row and header cells styles that intersect', function () {
+      const quill = this.initialize(
+        Quill,
+        `<table>
+          <tr style='text-align: right; color: #ff0000;'>
+            <th>1</th>
+            <th style='text-align: center; color: #00ff00'>2</th>
+          </tr>
+        </table>`,
+        this.container,
+        { modules: { table: true } },
+      );
+
+      expect(quill.root).toEqualHTML(`
+      <table>
+        <tbody>
+        <tr data-table-row='1'>
+          <td style='text-align: right;'>
+            <span style='color: rgb(255, 0, 0);'>1</span>
+          </td>
+          <td style='text-align: center;'>
+            <span style='color: rgb(0, 255, 0);'>2</span>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+      `);
+    });
+
+    it('initial markup with row and header cells styles that dont intersect', function () {
+      const quill = this.initialize(
+        Quill,
+        `<table>
+          <tr style='text-align: right; background-color: #3e3e3e;'>
+            <th>1</th>
+            <th style='color: #fff'>2</th>
+          </tr>
+        </table>`,
+        this.container,
+        { modules: { table: true } },
+      );
+
+      expect(quill.root).toEqualHTML(`
+      <table>
+        <tbody>
+        <tr data-table-row='1'>
+          <td style='background-color: rgb(62, 62, 62); text-align: right; '>
+            1
+          </td>
+          <td style='background-color: rgb(62, 62, 62); text-align: right; '>
+            <span style='color: rgb(255, 255, 255);'>2</span>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+      `);
     });
   });
 
@@ -521,7 +758,7 @@ describe('Table Module', function () {
         this.quill.format(`table${capitalize(formatName)}`, value);
         expect(this.quill.root).toEqualHTML(
           `
-            <table style="${styleName}: ${value};">
+            <table style='${styleName}: ${value};'>
               <tbody>
                 <tr>
                   <td>a1</td>
@@ -544,7 +781,7 @@ describe('Table Module', function () {
             <table>
               <tbody>
                 <tr>
-                  <td style="${styleName}: ${value};">a1</td>
+                  <td style='${styleName}: ${value};'>a1</td>
                   <td>a2</td>
                 </tr>
               </tbody>
@@ -591,7 +828,7 @@ describe('Table Module', function () {
         this.quill.format(`table${capitalize(formatName)}`, value);
         expect(this.quill.root).toEqualHTML(
           `
-            <table style="${styleName}: ${value};">
+            <table style='${styleName}: ${value};'>
               <thead>
                 <tr><th>h1</th><th>h2</th></tr>
               </thead>
@@ -617,7 +854,7 @@ describe('Table Module', function () {
             <table>
               <thead>
                 <tr>
-                  <th style="${styleName}: ${value};">h1</th>
+                  <th style='${styleName}: ${value};'>h1</th>
                   <th>h2</th>
                 </tr>
               </thead>

--- a/test/unit/modules/table_main.js
+++ b/test/unit/modules/table_main.js
@@ -453,6 +453,192 @@ describe('Table Module', function () {
       });
       expect(quill.root).toEqualHTML(expectedHtml, true);
     });
+
+    it('initial markup with row styles', function () {
+      const quill = this.initialize(
+        Quill,
+        `<table>
+          <tr style='text-align: right; background-color: #ff0000'>
+            <td>1</td>
+            <td>2</td>
+          </tr>
+        </table>`,
+        this.container,
+        { modules: { table: true } },
+      );
+
+      expect(quill.root).toEqualHTML(`
+      <table>
+        <tbody>
+        <tr>
+          <td class='ql-table-data-cell' style='text-align: right; background-color: rgb(255, 0, 0);'>
+            <p class='ql-table-cell-line'>1</p>
+          </td>
+          <td class='ql-table-data-cell' style='text-align: right; background-color: rgb(255, 0, 0);'>
+            <p class='ql-table-cell-line'>2</p>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+      `);
+    });
+
+    it('initial markup with row and cell styles that intersect', function () {
+      const quill = this.initialize(
+        Quill,
+        `<table>
+          <tr style='text-align: right; background-color: #ff0000;'>
+            <td>1</td>
+            <td style='text-align: center; background-color: #00ff00'>2</td>
+          </tr>
+        </table>`,
+        this.container,
+        { modules: { table: true } },
+      );
+
+      expect(quill.root).toEqualHTML(`
+      <table>
+        <tbody>
+        <tr data-table-row='1'>
+          <td class='ql-table-data-cell' data-table-row='1'
+              style='text-align: right; background-color: rgb(255, 0, 0);'>
+            <p class='ql-table-cell-line' data-table-row='1' data-table-cell='1'
+               data-cellbackgroundcolor='rgb(255, 0, 0)'
+               data-celltextalign='right'>
+              1
+            </p>
+          </td>
+          <td class='ql-table-data-cell' data-table-row='1'
+              style='text-align: center; background-color: rgb(0, 255, 0);'>
+            <p class='ql-table-cell-line' data-table-row='1' data-table-cell='2'
+               data-cellbackgroundcolor='rgb(0, 255, 0)'
+               data-celltextalign='center'>
+              2
+            </p>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+      `);
+    });
+
+    it('initial markup with row and cell styles that dont intersect', function () {
+      const quill = this.initialize(
+        Quill,
+        `<table>
+          <tr style='text-align: right; background-color: #3e3e3e;'>
+            <td>1</td>
+            <td style='color: #fff'>2</td>
+          </tr>
+          </table>`,
+        this.container,
+        { modules: { table: true } },
+      );
+
+      expect(quill.root).toEqualHTML(`
+      <table>
+        <tbody>
+        <tr data-table-row='1'>
+          <td class='ql-table-data-cell' data-table-row='1'
+              style='text-align: right; background-color: rgb(62, 62, 62);'>
+            <p class='ql-table-cell-line'
+               data-table-row='1' data-table-cell='1'
+               data-cellbackgroundcolor='rgb(62, 62, 62)'
+               data-celltextalign='right'>1
+            </p>
+          </td>
+          <td class='ql-table-data-cell' data-table-row='1'
+              style='text-align: right; background-color: rgb(62, 62, 62);'>
+            <p class='ql-table-cell-line'
+               data-table-row='1' data-table-cell='2'
+               data-cellbackgroundcolor='rgb(62, 62, 62)'
+               data-celltextalign='right'>
+               <span style='color: rgb(255, 255, 255);'>2</span>
+            </p>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+      `);
+    });
+
+    it('initial markup with row and header cells styles that intersect', function () {
+      const quill = this.initialize(
+        Quill,
+        `<table>
+          <tr style='text-align: right; color: #ff0000;'>
+            <th>1</th>
+            <th style='text-align: center; color: #00ff00'>2</th>
+          </tr>
+        </table>`,
+        this.container,
+        { modules: { table: true } },
+      );
+
+      expect(quill.root).toEqualHTML(`
+      <table>
+        <tbody>
+        <tr data-table-row='1'>
+          <td class='ql-table-data-cell' data-table-row='1' style='text-align: right;'>
+            <p class='ql-table-cell-line'
+               data-table-row='1'
+               data-table-cell='1'
+               data-celltextalign='right'>
+              <span style='color: rgb(255, 0, 0);'>1</span>
+            </p>
+          </td>
+          <td class='ql-table-data-cell' data-table-row='1' style='text-align: center;'>
+            <p class='ql-table-cell-line'
+               data-table-row='1'
+               data-table-cell='2'
+               data-celltextalign='center'>
+              <span style='color: rgb(0, 255, 0);'>2</span>
+            </p>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+      `);
+    });
+
+    it('initial markup with row and header cells styles that dont intersect', function () {
+      const quill = this.initialize(
+        Quill,
+        `<table>
+          <tr style='text-align: right; background-color: #3e3e3e;'>
+            <th>1</th>
+            <th style='color: #fff'>2</th>
+          </tr>
+        </table>`,
+        this.container,
+        { modules: { table: true } },
+      );
+
+      expect(quill.root).toEqualHTML(`
+      <table>
+        <tbody>
+        <tr data-table-row='1'>
+          <td class='ql-table-data-cell' data-table-row='1'
+              style='text-align: right; background-color: rgb(62, 62, 62);'>
+            <p class='ql-table-cell-line'
+               data-table-row='1' data-table-cell='1'
+               data-cellbackgroundcolor='rgb(62, 62, 62)'
+               data-celltextalign='right'>1</p>
+          </td>
+          <td class='ql-table-data-cell' data-table-row='1'
+              style='text-align: right; background-color: rgb(62, 62, 62);'>
+            <p class='ql-table-cell-line'
+               data-table-row='1' data-table-cell='2'
+               data-cellbackgroundcolor='rgb(62, 62, 62)'
+               data-celltextalign='right'>
+              <span style='color: rgb(255, 255, 255);'>2</span>
+            </p>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+      `);
+    });
   });
 
   describe('modify table', function () {


### PR DESCRIPTION
Fixed the issue of the missed table's row styles by collecting them from the parent node of the table's cells.