### PR TITLE
Update CI after 24_2 release and extracting devextreme-scss project

### DIFF
--- a/.github/actions/html-editor/common/prepare/action.yml
+++ b/.github/actions/html-editor/common/prepare/action.yml
@@ -41,10 +41,11 @@ runs:
         key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
         restore-keys: ${{ runner.os }}-node-modules
 
-    - name: Install .NET 6.0
+    - name: Install .NET 6
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6
+        runtime: dotnet
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/html-editor/common/prepare/action.yml
+++ b/.github/actions/html-editor/common/prepare/action.yml
@@ -42,6 +42,7 @@ runs:
         restore-keys: ${{ runner.os }}-node-modules
 
     - name: Install .NET 6.0
+      shell: bash
       run: |
         wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
         chmod +x dotnet-install.sh

--- a/.github/actions/html-editor/common/prepare/action.yml
+++ b/.github/actions/html-editor/common/prepare/action.yml
@@ -41,6 +41,12 @@ runs:
         key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
         restore-keys: ${{ runner.os }}-node-modules
 
+    - name: Install .NET 6.0
+      run: |
+        wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
+        chmod +x dotnet-install.sh
+        ./dotnet-install.sh --version 6.0.0
+
     - name: Install dependencies
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/html-editor/common/prepare/action.yml
+++ b/.github/actions/html-editor/common/prepare/action.yml
@@ -18,7 +18,7 @@ inputs:
   node-version:
     description: Node.js version
     required: true
-    default: '18'
+    default: '20'
 runs:
   using: composite
   steps:

--- a/.github/actions/html-editor/common/prepare/action.yml
+++ b/.github/actions/html-editor/common/prepare/action.yml
@@ -41,11 +41,10 @@ runs:
         key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
         restore-keys: ${{ runner.os }}-node-modules
 
-    - name: Install .NET 6
+    - name: Install .NET 6 SDK
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6
-        runtime: dotnet
+        dotnet-version: 6.0.x
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/html-editor/common/prepare/action.yml
+++ b/.github/actions/html-editor/common/prepare/action.yml
@@ -46,7 +46,7 @@ runs:
       run: |
         wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
         chmod +x dotnet-install.sh
-        ./dotnet-install.sh --version 6.0.0
+        ./dotnet-install.sh --channel 6.0
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/html-editor/common/prepare/action.yml
+++ b/.github/actions/html-editor/common/prepare/action.yml
@@ -46,11 +46,6 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: npm install --no-audit --no-fund
 
-    - name: Install css dependencies
-      shell: bash
-      working-directory: ${{ inputs.devextreme-scss-package-directory }}
-      run: npm install
-
     - name: Download quill ci package
       uses: actions/download-artifact@v3
       with:
@@ -66,3 +61,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: npm install --global cross-env
+
+    - name: Install css dependencies
+      shell: bash
+      working-directory: ${{ inputs.devextreme-scss-package-directory }}
+      run: npm install

--- a/.github/actions/html-editor/common/prepare/action.yml
+++ b/.github/actions/html-editor/common/prepare/action.yml
@@ -11,6 +11,10 @@ inputs:
   devextreme-package-directory:
     description: DevExtreme package path
     default: devextreme-repo
+  devextreme-scss-package-directory:
+    description: DevExtreme scss package path
+    required: true
+    default: devextreme-repo
   node-version:
     description: Node.js version
     required: true
@@ -41,6 +45,11 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: npm install --no-audit --no-fund
+
+    - name: Install css dependencies
+      shell: bash
+      working-directory: ${{ inputs.devextreme-scss-package-directory }}
+      run: npm install
 
     - name: Download quill ci package
       uses: actions/download-artifact@v3

--- a/.github/actions/html-editor/common/prepare/action.yml
+++ b/.github/actions/html-editor/common/prepare/action.yml
@@ -42,11 +42,9 @@ runs:
         restore-keys: ${{ runner.os }}-node-modules
 
     - name: Install .NET 6.0
-      shell: bash
-      run: |
-        wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
-        chmod +x dotnet-install.sh
-        ./dotnet-install.sh --channel 6.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/html-editor/steps/build/action.yml
+++ b/.github/actions/html-editor/steps/build/action.yml
@@ -41,7 +41,6 @@ runs:
       run: npm run build
 
     - name: Build:systemjs
-      if: ${{ !startsWith(inputs.branch, '22') }}
       shell: bash
       working-directory: ${{ inputs.devextreme-package-directory }}
       run: npm run build:systemjs

--- a/.github/actions/html-editor/steps/build/action.yml
+++ b/.github/actions/html-editor/steps/build/action.yml
@@ -40,7 +40,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.devextreme-package-directory }}
       run: |
-        7z a -tzip -mx3 -mmt2 devextreme-artifact.zip artifacts scss/bundles
+        7z a -tzip -mx3 -mmt2 devextreme-artifact.zip artifacts ../devextreme-scss/scss/bundles
 
     - name: Upload artifact
       uses: actions/upload-artifact@v3

--- a/.github/actions/html-editor/steps/build/action.yml
+++ b/.github/actions/html-editor/steps/build/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: DevExtreme package path
     required: true
     default: devextreme-repo
+  devextreme-scss-package-directory:
+    description: DevExtreme scss package path
+    required: true
+    default: devextreme-repo
 runs:
   using: composite
   steps:
@@ -20,6 +24,7 @@ runs:
       with:
         branch: ${{ inputs.branch }}
         working-directory: ${{ inputs.working-directory }}
+        devextreme-scss-package-directory: ${{ inputs.devextreme-scss-package-directory }}
 
     - name: Build
       shell: bash
@@ -28,6 +33,11 @@ runs:
         BUILD_TEST_INTERNAL_PACKAGE: 'true'
         DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 'true'
+      run: npm run build
+
+    - name: Build scss
+      shell: bash
+      working-directory: ${{ inputs.devextreme-scss-package-directory }}
       run: npm run build
 
     - name: Build:systemjs

--- a/.github/actions/html-editor/steps/testcafe-tests/action.yml
+++ b/.github/actions/html-editor/steps/testcafe-tests/action.yml
@@ -51,7 +51,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.e2e-package-directory }}
       run: |
-        all_args="--concurrency 2 --browsers=chrome:devextreme-shr2 --componentFolder ${{ inputs.component-directory }} --quarantineMode ${{ env.TEST_SUITE.quarantineMode}}"
+        all_args="--concurrency 1 --browsers=chrome:devextreme-shr2 --componentFolder ${{ inputs.component-directory }} --quarantineMode ${{ env.TEST_SUITE.quarantineMode}}"
         echo "$all_args"
         npx nx test $all_args
 

--- a/.github/actions/html-editor/steps/testcafe-tests/action.yml
+++ b/.github/actions/html-editor/steps/testcafe-tests/action.yml
@@ -44,6 +44,8 @@ runs:
     - name: Setup chrome
       if: ${{ !startsWith(inputs.branch, '22') }}
       uses: ./devextreme-repo/.github/actions/setup-chrome
+      with:
+        chrome-version: '121.0.6167.160'
 
     - name: Prepare localization
       shell: bash

--- a/.github/actions/html-editor/steps/testcafe-tests/action.yml
+++ b/.github/actions/html-editor/steps/testcafe-tests/action.yml
@@ -53,7 +53,7 @@ runs:
       run: |
         all_args="--concurrency 1 --browsers=chrome:devextreme-shr2 --componentFolder ${{ inputs.component-directory }} --quarantineMode ${{ env.TEST_SUITE.quarantineMode}}"
         echo "$all_args"
-        npx nx test $all_args
+        npm run test -- $all_args
 
     - name: Copy compared screenshot artifacts
       if: ${{ failure() }}

--- a/.github/actions/html-editor/steps/testcafe-tests/action.yml
+++ b/.github/actions/html-editor/steps/testcafe-tests/action.yml
@@ -53,7 +53,7 @@ runs:
       run: |
         all_args="--concurrency 2 --browsers=chrome:devextreme-shr2 --componentFolder ${{ inputs.component-directory }} --quarantineMode ${{ env.TEST_SUITE.quarantineMode}}"
         echo "$all_args"
-        npm run test -- $all_args
+        npx nx test $all_args
 
     - name: Copy compared screenshot artifacts
       if: ${{ failure() }}

--- a/.github/actions/html-editor/steps/testcafe-tests/action.yml
+++ b/.github/actions/html-editor/steps/testcafe-tests/action.yml
@@ -37,12 +37,7 @@ runs:
         branch: ${{ inputs.branch }}
         working-directory: ${{ inputs.devextreme-package-directory }}
 
-    - name: Pin browsers
-      if: ${{ startsWith(inputs.branch, '22') }}
-      uses: ./devextreme-repo/.github/actions/pin-browsers
-
     - name: Setup chrome
-      if: ${{ !startsWith(inputs.branch, '22') }}
       uses: ./devextreme-repo/.github/actions/setup-chrome
       with:
         chrome-version: '121.0.6167.160'

--- a/.github/workflows/html-editor-checks.yml
+++ b/.github/workflows/html-editor-checks.yml
@@ -80,7 +80,7 @@ jobs:
 
   testcafe:
     needs: [build-devextreme, set-up-branches]
-    runs-on: devextreme-shr2
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     name: testcafe ${{ matrix.branch }}
     strategy:

--- a/.github/workflows/html-editor-checks.yml
+++ b/.github/workflows/html-editor-checks.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           branch: ${{ matrix.branch }}
           devextreme-package-directory: ${{ 'devextreme-repo/packages/devextreme' }}
+          devextreme-scss-package-directory: ${{ 'devextreme-repo/packages/devextreme-scss' }}
 
   qunit:
     needs: [build-devextreme, set-up-branches]

--- a/.github/workflows/html-editor-checks.yml
+++ b/.github/workflows/html-editor-checks.yml
@@ -80,7 +80,7 @@ jobs:
 
   testcafe:
     needs: [build-devextreme, set-up-branches]
-    runs-on: ubuntu-latest
+    runs-on: devextreme-shr2
     timeout-minutes: 15
     name: testcafe ${{ matrix.branch }}
     strategy:

--- a/.github/workflows/html-editor-checks.yml
+++ b/.github/workflows/html-editor-checks.yml
@@ -80,7 +80,7 @@ jobs:
 
   testcafe:
     needs: [build-devextreme, set-up-branches]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     name: testcafe ${{ matrix.branch }}
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,3 +36,4 @@ jobs:
         run: |
           npm dist-tag add devextreme-quill@${{ inputs.version }} 24_1
           npm dist-tag add devextreme-quill@${{ inputs.version }} 24_2
+          npm dist-tag add devextreme-quill@${{ inputs.version }} 25_1


### PR DESCRIPTION
- Build DevExtreme SCSS manually after it has been extracted into a separate project.
- Install .NET 6 manually since it is not automatically installed on Ubuntu 22.04.
- To make TestCafe tests work, fix the Ubuntu, Node.js, and Chrome versions to match those used in 24_1.
- Remove actions specific to 22.* DevExtreme branches.
- Add a 25_1 branch for npm tagging when publishing a new package.