### PR TITLE
Cherry-pick SVG sanitizing to 1_6 and bump to 1.6.5

### DIFF
--- a/.github/actions/html-editor/common/get-artifact/action.yml
+++ b/.github/actions/html-editor/common/get-artifact/action.yml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Download artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: devextreme-artifact-${{ inputs.branch }}
         path: ${{ inputs.working-directory }}

--- a/.github/actions/html-editor/common/prepare/action.yml
+++ b/.github/actions/html-editor/common/prepare/action.yml
@@ -34,6 +34,11 @@ runs:
         key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
         restore-keys: ${{ runner.os }}-node-modules
 
+    - name: Install .NET 6 SDK
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+
     - name: Install dependencies
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/html-editor/common/prepare/action.yml
+++ b/.github/actions/html-editor/common/prepare/action.yml
@@ -40,7 +40,7 @@ runs:
       run: npm install --no-audit --no-fund
 
     - name: Download quill ci package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: quill-package
         path: ${{ inputs.working-directory }}

--- a/.github/actions/html-editor/steps/build/action.yml
+++ b/.github/actions/html-editor/steps/build/action.yml
@@ -44,7 +44,7 @@ runs:
         7z a -tzip -mx3 -mmt2 devextreme-artifact.zip artifacts scss/bundles
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: devextreme-artifact-${{ inputs.branch }}
         path: ${{ inputs.devextreme-package-directory }}/devextreme-artifact.zip

--- a/.github/actions/html-editor/steps/testcafe-tests/action.yml
+++ b/.github/actions/html-editor/steps/testcafe-tests/action.yml
@@ -56,7 +56,7 @@ runs:
 
     - name: Copy compared screenshot artifacts
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: compared-screenshots
         path: ${{ inputs.devextreme-package-directory }}/testing/testcafe/artifacts/compared-screenshots/**/*
@@ -64,7 +64,7 @@ runs:
 
     - name: Copy failed test artifacts
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: failed-tests
         path: ${{ inputs.devextreme-package-directory }}/testing/testcafe/artifacts/failedtests/**/*

--- a/.github/actions/quill/common/get-artifact/action.yml
+++ b/.github/actions/quill/common/get-artifact/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Download artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: quill-artifact
 

--- a/.github/actions/quill/steps/build-package/action.yml
+++ b/.github/actions/quill/steps/build-package/action.yml
@@ -19,7 +19,7 @@ runs:
       run: npm pack
 
     - name: Upload package artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: quill-package
         path: devextreme-quill-0.0.0-ci.tgz

--- a/.github/actions/quill/steps/build/action.yml
+++ b/.github/actions/quill/steps/build/action.yml
@@ -15,7 +15,7 @@ runs:
       run: |
         7z a -tzip -mx3 -mmt2 quill-artifact.zip dist
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: quill-artifact
         path: quill-artifact.zip

--- a/.github/workflows/html-editor-checks.yml
+++ b/.github/workflows/html-editor-checks.yml
@@ -74,29 +74,3 @@ jobs:
           branch: ${{ matrix.branch }}
           devextreme-package-directory: ${{ (matrix.branch == '23_2') && 'devextreme-repo/packages/devextreme' || 'devextreme-repo' }}
           test-suite: ${{ matrix.test-suite }}
-
-  testcafe:
-    needs: [build-devextreme, set-up-branches]
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    name: testcafe ${{ matrix.branch }}
-    strategy:
-      fail-fast: false
-      matrix:
-        branch: ${{ fromJson(needs.set-up-branches.outputs.branches) }}
-        test-suite: [
-          { componentFolder: 'htmlEditor', quarantineMode: false },
-        ]
-    steps:
-      - name: Checkout Quill repository
-        uses: actions/checkout@v3
-        with:
-          path: quill-repo
-
-      - name: Testcafe tests
-        uses: ./quill-repo/.github/actions/html-editor/steps/testcafe-tests
-        with:
-          branch: ${{ matrix.branch }}
-          devextreme-package-directory: ${{ (matrix.branch == '23_2') && 'devextreme-repo/packages/devextreme' || 'devextreme-repo' }}
-          component-directory: ${{ matrix.test-suite.componentFolder }}
-          quarantine-mode: ${{ matrix.test-suite.quarantineMode }}

--- a/.github/workflows/html-editor-checks.yml
+++ b/.github/workflows/html-editor-checks.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  DEVEXTREME_BRANCHES: '["24_1", "23_2", "23_1", "22_2", "22_1"]'
+  DEVEXTREME_BRANCHES: '["23_2", "23_1", "22_2", "22_1"]'
 
 jobs:
   set-up-branches:
@@ -50,7 +50,7 @@ jobs:
         uses: ./quill-repo/.github/actions/html-editor/steps/build
         with:
           branch: ${{ matrix.branch }}
-          devextreme-package-directory: ${{ (matrix.branch == '23_2' || matrix.branch == '24_1') && 'devextreme-repo/packages/devextreme' || 'devextreme-repo' }}
+          devextreme-package-directory: ${{ (matrix.branch == '23_2') && 'devextreme-repo/packages/devextreme' || 'devextreme-repo' }}
 
   qunit:
     needs: [build-devextreme, set-up-branches]
@@ -72,7 +72,7 @@ jobs:
         uses: ./quill-repo/.github/actions/html-editor/steps/qunit-tests
         with:
           branch: ${{ matrix.branch }}
-          devextreme-package-directory: ${{ (matrix.branch == '23_2' || matrix.branch == '24_1') && 'devextreme-repo/packages/devextreme' || 'devextreme-repo' }}
+          devextreme-package-directory: ${{ (matrix.branch == '23_2') && 'devextreme-repo/packages/devextreme' || 'devextreme-repo' }}
           test-suite: ${{ matrix.test-suite }}
 
   testcafe:
@@ -97,6 +97,6 @@ jobs:
         uses: ./quill-repo/.github/actions/html-editor/steps/testcafe-tests
         with:
           branch: ${{ matrix.branch }}
-          devextreme-package-directory: ${{ (matrix.branch == '23_2' || matrix.branch == '24_1') && 'devextreme-repo/packages/devextreme' || 'devextreme-repo' }}
+          devextreme-package-directory: ${{ (matrix.branch == '23_2') && 'devextreme-repo/packages/devextreme' || 'devextreme-repo' }}
           component-directory: ${{ matrix.test-suite.componentFolder }}
           quarantine-mode: ${{ matrix.test-suite.quarantineMode }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,5 +35,4 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm dist-tag add devextreme-quill@${{ inputs.version }} 23_1
           npm dist-tag add devextreme-quill@${{ inputs.version }} 23_2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "devextreme-quill",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "devextreme-quill",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "core-js": "^3.34.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devextreme-quill",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Core of the DevExtreme HtmlEditor",
   "author": "Developer Express Inc.",
   "main": "dist/dx-quill.js",

--- a/test/unit.js
+++ b/test/unit.js
@@ -33,7 +33,6 @@ import './unit/modules/table_lite';
 import './unit/modules/table_main';
 import './unit/modules/uploader';
 
-import './unit/utils/is_equal';
 import './unit/utils/sanitize_svg';
 
 // Syntax version will otherwise be registered

--- a/test/unit.js
+++ b/test/unit.js
@@ -33,6 +33,9 @@ import './unit/modules/table_lite';
 import './unit/modules/table_main';
 import './unit/modules/uploader';
 
+import './unit/utils/is_equal';
+import './unit/utils/sanitize_svg';
+
 // Syntax version will otherwise be registered
 Quill.register(CodeBlockContainer, true);
 Quill.register(CodeBlock, true);

--- a/test/unit/utils/sanitize_svg.js
+++ b/test/unit/utils/sanitize_svg.js
@@ -1,0 +1,166 @@
+import sanitizeSvg from '../../../utils/sanitize_svg';
+
+describe('sanitizeSvg', function () {
+  it('should return null for non-SVG root', function () {
+    const input = '<div><span>Test</span></div>';
+
+    expect(sanitizeSvg(input)).toBeNull();
+  });
+
+  it('should keep allowed svg structure', function () {
+    const input = '<svg><g><circle cx="10" cy="10" r="5"></circle></g></svg>';
+
+    const output = sanitizeSvg(input);
+
+    const doc = new DOMParser().parseFromString(output, 'image/svg+xml');
+    const circle = doc.querySelector('circle');
+
+    expect(output).not.toBeNull();
+    expect(circle).not.toBeNull();
+    expect(circle.getAttribute('cx')).toEqual('10');
+    expect(circle.getAttribute('r')).toEqual('5');
+  });
+
+  it('should remove banned and unknown tags', function () {
+    const input = '<svg><script>alert(1)</script><unknown><circle cx="1" cy="1" r="1" /></unknown><circle cx="2" cy="2" r="2" /></svg>';
+
+    const output = sanitizeSvg(input);
+
+    const doc = new DOMParser().parseFromString(output, 'image/svg+xml');
+
+    expect(doc.querySelector('script')).toBeNull();
+    expect(doc.querySelector('unknown')).toBeNull();
+    expect(doc.querySelectorAll('circle').length).toEqual(1);
+  });
+
+  it('should remove banned attributes', function () {
+    const input = '<svg foo="bar"><g bar="foo" custom="x"><circle cx="5" cy="5" r="2" bad="yes" /></g></svg>';
+
+    const output = sanitizeSvg(input);
+
+    const doc = new DOMParser().parseFromString(output, 'image/svg+xml');
+    const svg = doc.documentElement;
+    const g = doc.querySelector('g');
+    const circle = doc.querySelector('circle');
+
+    expect(svg.hasAttribute('foo')).toBeFalse();
+    expect(g.hasAttribute('bar')).toBeFalse();
+    expect(g.hasAttribute('custom')).toBeFalse();
+    expect(circle.hasAttribute('bad')).toBeFalse();
+    expect(circle.getAttribute('cx')).toEqual('5');
+  });
+
+  it('should strip event handler attributes', function () {
+    const input = '<svg><g onclick="alert(1)"><circle onmouseover="alert(2)" cx="3" cy="3" r="1" /></g></svg>';
+
+    const output = sanitizeSvg(input);
+
+    const doc = new DOMParser().parseFromString(output, 'image/svg+xml');
+    const g = doc.querySelector('g');
+    const circle = doc.querySelector('circle');
+
+    expect(g.hasAttribute('onclick')).toBeFalse();
+    expect(circle.hasAttribute('onmouseover')).toBeFalse();
+  });
+
+  it('should keep safe href (#anchor)', function () {
+    const input = '<svg><a href="#anchor"><text>Link</text></a></svg>';
+
+    const output = sanitizeSvg(input);
+
+    const doc = new DOMParser().parseFromString(output, 'image/svg+xml');
+    const a = doc.querySelector('a');
+
+    expect(a.getAttribute('href')).toEqual('#anchor');
+  });
+
+  it('should keep data:image href and remove others (data, http, https, javascript)', function () {
+    const input = '<svg>'
+      + '<a id="a1" href="data:image/png;base64,AAAA" />'
+      + '<a id="a2" href="data:text/plain;base64,BBBB" />'
+      + '<a id="a3" href="http://example.com" />'
+      + '<a id="a4" href="https://example.com" />'
+      + '<a id="a5" href="javascript:alert(1)" />'
+      + '</svg>';
+
+    const output = sanitizeSvg(input);
+
+    const doc = new DOMParser().parseFromString(output, 'image/svg+xml');
+    const a1 = doc.getElementById('a1');
+    const a2 = doc.getElementById('a2');
+    const a3 = doc.getElementById('a3');
+    const a4 = doc.getElementById('a4');
+    const a5 = doc.getElementById('a5');
+
+    expect(a1.getAttribute('href')).toEqual('data:image/png;base64,AAAA');
+    expect(a2.hasAttribute('href')).toBeFalse();
+    expect(a3.hasAttribute('href')).toBeFalse();
+    expect(a4.hasAttribute('href')).toBeFalse();
+    expect(a5.hasAttribute('href')).toBeFalse();
+  });
+
+  it('should sanitize nested structure recursively', function () {
+    const input = '<svg><g><g><script>alert(1)</script><circle cx="1" cy="1" r="1" onclick="foo()" /></g></g></svg>';
+
+    const output = sanitizeSvg(input);
+
+    const doc = new DOMParser().parseFromString(output, 'image/svg+xml');
+    const circle = doc.querySelector('circle');
+
+    expect(doc.querySelector('script')).toBeNull();
+    expect(circle).not.toBeNull();
+    expect(circle.hasAttribute('onclick')).toBeFalse();
+  });
+
+  it('should preserve allowed attributes (fill, stroke, transform, id)', function () {
+    const input = '<svg id="root" viewBox="0 0 10 10" foo="bar"><g id="grp" transform="translate(1,1)" bar="baz"><path id="p1" d="M0 0 L5 5" fill="#fff" stroke="#000" stroke-width="2" custom="x" /></g></svg>';
+
+    const output = sanitizeSvg(input);
+
+    const doc = new DOMParser().parseFromString(output, 'image/svg+xml');
+    const svg = doc.documentElement;
+    const g = doc.getElementById('grp');
+    const path = doc.getElementById('p1');
+
+    expect(svg.getAttribute('id')).toEqual('root');
+    expect(svg.hasAttribute('foo')).toBeFalse();
+    expect(g.getAttribute('transform')).toEqual('translate(1,1)');
+    expect(g.hasAttribute('bar')).toBeFalse();
+    expect(path.getAttribute('fill')).toEqual('#fff');
+    expect(path.getAttribute('stroke')).toEqual('#000');
+    expect(path.getAttribute('stroke-width')).toEqual('2');
+    expect(path.hasAttribute('custom')).toBeFalse();
+  });
+
+  it('should treat attribute names as case-sensitive and drop uppercased ones', function () {
+    const input = '<svg><circle CX="10" cy="11" R="5" r="6" FILL="red" fill="blue"></circle></svg>';
+
+    const output = sanitizeSvg(input);
+
+    const doc = new DOMParser().parseFromString(output, 'image/svg+xml');
+    const circle = doc.querySelector('circle');
+
+    expect(circle.hasAttribute('CX')).toBeFalse();
+    expect(circle.getAttribute('cy')).toEqual('11');
+    expect(circle.hasAttribute('R')).toBeFalse();
+    expect(circle.getAttribute('r')).toEqual('6');
+    expect(circle.hasAttribute('FILL')).toBeFalse();
+    expect(circle.getAttribute('fill')).toEqual('blue');
+  });
+
+  it('should return null for empty or whitespace-only input', function () {
+    expect(sanitizeSvg('')).toBeNull();
+    expect(sanitizeSvg('   ')).toBeNull();
+  });
+
+  it('should remove banned tag even if attributes are safe', function () {
+    const input = '<svg><defs><path id="icon" d="M0 0 L1 1" /></defs><use href="#icon" x="0" y="0" /></svg>';
+
+    const output = sanitizeSvg(input);
+
+    const doc = new DOMParser().parseFromString(output, 'image/svg+xml');
+
+    expect(doc.querySelector('defs path')).not.toBeNull();
+    expect(doc.querySelector('use')).toBeNull();
+  });
+});

--- a/utils/sanitize_svg.js
+++ b/utils/sanitize_svg.js
@@ -1,0 +1,315 @@
+export const allowedTags = Object.freeze([
+  'svg',
+  'a',
+  'altglyph',
+  'altglyphdef',
+  'altglyphitem',
+  'animatecolor',
+  'animatemotion',
+  'animatetransform',
+  'circle',
+  'clippath',
+  'defs',
+  'desc',
+  'ellipse',
+  'enterkeyhint',
+  'exportparts',
+  'filter',
+  'font',
+  'g',
+  'glyph',
+  'glyphref',
+  'hkern',
+  'image',
+  'inputmode',
+  'line',
+  'lineargradient',
+  'marker',
+  'mask',
+  'metadata',
+  'mpath',
+  'part',
+  'path',
+  'pattern',
+  'polygon',
+  'polyline',
+  'radialgradient',
+  'rect',
+  'slot',
+  'stop',
+  'style',
+  'switch',
+  'symbol',
+  'text',
+  'textpath',
+  'title',
+  'tref',
+  'tspan',
+  'view',
+  'vkern',
+]);
+
+export const allowedAttributes = Object.freeze([
+  'accent-height',
+  'accumulate',
+  'additive',
+  'alignment-baseline',
+  'amplitude',
+  'ascent',
+  'attributename',
+  'attributetype',
+  'azimuth',
+  'basefrequency',
+  'baseline-shift',
+  'begin',
+  'bias',
+  'by',
+  'class',
+  'clip',
+  'clippathunits',
+  'clip-path',
+  'clip-rule',
+  'color',
+  'color-interpolation',
+  'color-interpolation-filters',
+  'color-profile',
+  'color-rendering',
+  'cx',
+  'cy',
+  'd',
+  'dx',
+  'dy',
+  'diffuseconstant',
+  'direction',
+  'display',
+  'divisor',
+  'dur',
+  'edgemode',
+  'elevation',
+  'end',
+  'exponent',
+  'fill',
+  'fill-opacity',
+  'fill-rule',
+  'filter',
+  'filterunits',
+  'flood-color',
+  'flood-opacity',
+  'font-family',
+  'font-size',
+  'font-size-adjust',
+  'font-stretch',
+  'font-style',
+  'font-variant',
+  'font-weight',
+  'fx',
+  'fy',
+  'g1',
+  'g2',
+  'glyph-name',
+  'glyphref',
+  'gradientunits',
+  'gradienttransform',
+  'height',
+  'href',
+  'id',
+  'image-rendering',
+  'in',
+  'in2',
+  'intercept',
+  'k',
+  'k1',
+  'k2',
+  'k3',
+  'k4',
+  'kerning',
+  'keypoints',
+  'keysplines',
+  'keytimes',
+  'lang',
+  'lengthadjust',
+  'letter-spacing',
+  'kernelmatrix',
+  'kernelunitlength',
+  'lighting-color',
+  'local',
+  'marker-end',
+  'marker-mid',
+  'marker-start',
+  'markerheight',
+  'markerunits',
+  'markerwidth',
+  'maskcontentunits',
+  'maskunits',
+  'max',
+  'mask',
+  'media',
+  'method',
+  'mode',
+  'min',
+  'name',
+  'numoctaves',
+  'offset',
+  'operator',
+  'opacity',
+  'order',
+  'orient',
+  'orientation',
+  'origin',
+  'overflow',
+  'paint-order',
+  'path',
+  'pathlength',
+  'patterncontentunits',
+  'patterntransform',
+  'patternunits',
+  'points',
+  'preservealpha',
+  'preserveaspectratio',
+  'primitiveunits',
+  'r',
+  'rx',
+  'ry',
+  'radius',
+  'refx',
+  'refy',
+  'repeatcount',
+  'repeatdur',
+  'restart',
+  'result',
+  'rotate',
+  'scale',
+  'seed',
+  'shape-rendering',
+  'slope',
+  'specularconstant',
+  'specularexponent',
+  'spreadmethod',
+  'startoffset',
+  'stddeviation',
+  'stitchtiles',
+  'stop-color',
+  'stop-opacity',
+  'stroke-dasharray',
+  'stroke-dashoffset',
+  'stroke-linecap',
+  'stroke-linejoin',
+  'stroke-miterlimit',
+  'stroke-opacity',
+  'stroke',
+  'stroke-width',
+  'style',
+  'surfacescale',
+  'systemlanguage',
+  'tabindex',
+  'tablevalues',
+  'targetx',
+  'targety',
+  'transform',
+  'transform-origin',
+  'text-anchor',
+  'text-decoration',
+  'text-rendering',
+  'textlength',
+  'type',
+  'u1',
+  'u2',
+  'unicode',
+  'values',
+  'viewbox',
+  'visibility',
+  'version',
+  'vert-adv-y',
+  'vert-origin-x',
+  'vert-origin-y',
+  'width',
+  'word-spacing',
+  'wrap',
+  'writing-mode',
+  'xchannelselector',
+  'ychannelselector',
+  'x',
+  'x1',
+  'x2',
+  'xmlns',
+  'y',
+  'y1',
+  'y2',
+  'z',
+  'zoomandpan',
+  'xlink:href',
+  'xml:id',
+  'xlink:title',
+  'xml:space',
+  'xmlns:xlink',
+]);
+
+function isSafeUrl(value) {
+  if (!value) return false;
+
+  const lower = value.trim().toLowerCase();
+
+  if (
+    lower.startsWith('#')
+    || lower.startsWith('data:image/')
+  ) {
+    return true;
+  }
+
+  if (
+    // eslint-disable-next-line no-script-url
+    lower.startsWith('javascript:')
+    || lower.startsWith('vbscript:')
+    || lower.startsWith('data:')
+    || lower.startsWith('http:')
+    || lower.startsWith('https:')
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function sanitizeNode(node) {
+  const tagName = node.tagName.toLowerCase();
+
+  if (!allowedTags.includes(tagName)) {
+    node.remove();
+    return;
+  }
+
+  [...node.attributes].forEach((attr) => {
+    const { name, value } = attr;
+
+    if (!allowedAttributes.includes(name)) {
+      node.removeAttribute(name);
+      return;
+    }
+
+    if (name.startsWith('on')) {
+      node.removeAttribute(name);
+      return;
+    }
+
+    if ((name === 'href' || name === 'xlink:href') && !isSafeUrl(value)) {
+      node.removeAttribute(name);
+    }
+  });
+
+  [...node.children].forEach((child) => sanitizeNode(child));
+}
+
+export default function sanitizeSvg(svgString) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(svgString, 'image/svg+xml');
+
+  const svgElement = doc.documentElement;
+
+  if (!svgElement || svgElement.tagName.toLowerCase() !== 'svg') {
+    return null;
+  }
+
+  sanitizeNode(svgElement);
+
+  return svgElement.outerHTML;
+}


### PR DESCRIPTION
It's a cherry-pick of https://github.com/DevExpress/devextreme-quill/pull/159 to 1_6.

Additionally:
- 23_1 npm tag is not linked anymore
- upload-artifacts and download-artifacts are updated to v4
- custom `is_equal` is not used in this version
- remove 24_1 from CI checks - it's already linked to 1_7 version
- install .NET 6 manually since it is not automatically installed on Ubuntu 22.04 to reanimate unit tests
- disable testcafe testing (by analogy with the master branch)
- bump to 1_6_5