### PR TITLE
Ignore created tgz / zip artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /dist
 /node_modules
+*.tgz
+*.zip
 /selenium
 /docs/_site
 /src


### PR DESCRIPTION
Causes:

```
Run pnpm publish "$PACKAGE_TGZ" --provenance 
[ERR_PNPM_GIT_UNCLEAN] Unclean working tree. Commit or stash changes first.

If you want to disable Git checks on publish, set the "git-checks" setting to "false", or run again with "--no-git-checks".
```

On publish
After:
- #237