### PR TITLE
Security: update vulnerable dependencies (nanoid)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   body-parser@<2.3.0: ^2.3.0
   postcss@<8.5.18: ^8.5.18
   socket.io-parser@<4.2.7: ^4.2.7
+  nanoid@<3.3.18: ^3.3.18
 
 importers:
 
@@ -3620,13 +3621,8 @@ packages:
     engines: {npm: '>=1.4.0'}
     hasBin: true
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -9048,9 +9044,7 @@ snapshots:
 
   mustache@2.3.2: {}
 
-  nanoid@3.3.12: {}
-
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare-lite@1.4.0: {}
 
@@ -9379,7 +9373,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -10120,7 +10114,7 @@ snapshots:
       lodash: 4.18.1
       mkdirp: 0.5.6
       mustache: 2.3.2
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       os-family: 1.1.0
       pify: 2.3.0
       pinkie: 2.0.4
@@ -10147,7 +10141,7 @@ snapshots:
       merge-stream: 1.0.1
       mime: 1.4.1
       mustache: 2.3.2
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       os-family: 1.1.0
       parse5: 7.3.0
       pinkie: 2.0.4
@@ -10258,7 +10252,7 @@ snapshots:
       moment: 2.30.1
       moment-duration-format-commonjs: 1.0.1
       mustache: 2.3.2
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       os-family: 1.1.0
       parse5: 1.5.1
       pify: 2.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,7 @@ overrides:
   body-parser@<2.3.0: ^2.3.0
   postcss@<8.5.18: ^8.5.18
   'socket.io-parser@<4.2.7': ^4.2.7
+  nanoid@<3.3.18: ^3.3.18
 
 allowBuilds:
   core-js: true


### PR DESCRIPTION
Fixes two nanoid advisories reported by the repository check:

- GHSA-28wg-ghj8-5hjv — non-secure generators can loop indefinitely with negative size (vulnerable `< 3.3.16`)
- GHSA-2v37-7h3g-55p8 — custom generators can loop indefinitely when size is zero (vulnerable `< 3.3.18`)

The lockfile carried two copies: `3.3.12` (testcafe, testcafe-hammerhead, testcafe-browser-tools) and `3.3.16` (postcss) — an override on postcss re-resolves only its own subtree, so the testcafe copy stayed stale. A single `nanoid@<3.3.18: ^3.3.18` override in `pnpm-workspace.yaml` collapses both into `3.3.18`; the higher floor covers both advisories, so no second range entry is needed.

Verified locally: `pnpm install --frozen-lockfile` is a no-op, `pnpm audit` reports no known vulnerabilities, exactly one `nanoid@3.3.18` remains in the tree, and `pnpm run build` compiles. nanoid is build/test-only here — it does not appear in `dist/`, so the shipped bundle is unaffected.